### PR TITLE
Fixed a typo in README, Removed a redundent api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ What I needed to impliment:
     Select the appropriate State
     The country is predefinded as US (maybe change that later)
     Click the search button.
-    You will see a forecast displayed for you searched city.
-    A new button with your searched city will also display below the search button
+    You will see a forecast displayed for the searched city.
+    A new button with the searched city will also display below the search button
     This button when clicked will refresh and display the forecast again.
     You can also delete the button if you no longer want that city to display.
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -115,7 +115,7 @@ function displaySavedCities () {
     cityButton.addEventListener('click', function(event) {
       event.preventDefault()
       event.stopPropagation()
-      findCity(city.name, city.state, city.country)  
+      getForecast(city.lat, city.lon)  
     })
 
     cityDelete.addEventListener('click', function(event) {


### PR DESCRIPTION
I was calling the findCity() when I had the information to just call the getForecast() so I reduced an api call